### PR TITLE
feat: add toc

### DIFF
--- a/inst/documents/log.qmd
+++ b/inst/documents/log.qmd
@@ -11,6 +11,7 @@ params:
 format:
   html:
     embed-resources: true
+    toc: true
 ---
 
 ```{r, echo=FALSE}


### PR DESCRIPTION
Added default toc to the quarto html log.
Other options can be seen here: https://quarto.org/docs/reference/formats/html.html#table-of-contents