### PR TITLE
fix: render other md log formats("gfm", "commonmark", "markua")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Logging package
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/R/mdformats.R
+++ b/R/mdformats.R
@@ -1,13 +1,13 @@
 #' @noRd
-mdformats <- function(script, log_html, mdfmt, out_dir) {
+mdformats <- function(script, log_html, mdfmt, self, out_dir) {
   newname <- gsub(
     pattern = "\\.[^\\.]*$",
     replacement = "",
     x = basename(script)
   )
 
-  if (length(mdfmt) > 1) {
-    newname <- paste0(newname, "_", mdfmt)
+  if (length(mdfmt) >= 1) {
+    newname <- paste0(newname, "_log_", mdfmt)
   }
 
   newname <- paste0(newname, ".md")
@@ -20,14 +20,7 @@ mdformats <- function(script, log_html, mdfmt, out_dir) {
     )
 
     file.copy(
-      from = file.path(
-        tempdir(),
-        gsub(
-          pattern = "\\.[^\\.]*$",
-          replacement = ".md",
-          x = basename(log_html)
-        )
-      ),
+      from = file.path(self$get_wd(), "log.md"),
       to = file.path(
         out_dir,
         newname[[i]]

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -200,7 +200,7 @@ wq_next_step <- function(self, private, wid) {
             purrr::pluck(private$.queue, "result", id_script) <- session$
               log_finish()$
               create_outputs(out_dir = dirname(purrr::pluck(private$.queue, "script", id_script)),
-                             format = "html")
+                             format = options::opt("out_formats", env = "whirl"))
 
             purrr::pluck(private$.queue, "status", id_script) <-
               purrr::pluck(private$.queue, "result", id_script, "status", "status")

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -349,7 +349,8 @@ wrs_create_outputs <- function(out_dir, format, self, private, super) {
       script = private$current_script,
       log_html = file.path(self$get_wd(), "log.html"),
       mdfmt = format[format %in% c("gfm", "commonmark", "markua")],
-      out_dir = out_dir
+      out_dir = out_dir,
+      self = self
     )
   }
 


### PR DESCRIPTION
Updates
- updated location of temporary files for md
- updated name of log to end in `<filename>_log_<md type>.md`
- used options for create_outputs format argument

Steps

```
library(whirl)
options(whirl.out_formats = c("html", "gfm", "commonmark", "markua"))
options::opt("out_formats", env = "whirl")
result <- run("inst/examples/simple/prg1.R")
```

Expected files output at the same location as code
![image](https://github.com/user-attachments/assets/7451c3da-c408-4b91-af7f-36c519b869fd)

Follow-up - potential tickets/issues

1. Do we want to track this files in the summary html? and/or
2. Do we need different formats for the summary?
