### PR TITLE
fix: R CMD BUILD of vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@ plot1.png
 ^whirl\.Rcheck$
 ^whirl.*\.tar\.gz$
 ^whirl.*\.tgz$
+^vignettes/articles$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: whirl
 Title: Logging package
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = "aut"),
     person("Kristian", "Troejelsgaard", , "ktqn@novonordisk.com", role = "aut"),
-    person("Steffen Falgreen", family = "Larsen", email = "sffl@novonordisk.com", role = "aut"),
-    person(given = "VLOB (Vladimir Obucina)", role = "aut", email = "vlob@novonordisk.com"),
+    person("Steffen Falgreen", "Larsen", , "sffl@novonordisk.com", role = "aut"),
+    person("Vladimir", "Obucina", , email = "vlob@novonordisk.com", role = "aut"),
     person("Novo Nordisk A/S", role = "cph")
   )
 Description: Provides functionalities for running R scripts in batch, while simultanously creating logs for each script execution.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://nn-opensource.github.io/whirl/
+url: https://novonordisk-opensource.github.io/whirl/
 
 template:
   bootstrap: 5

--- a/man/whirl-package.Rd
+++ b/man/whirl-package.Rd
@@ -27,7 +27,7 @@ Authors:
   \item Cervan Girard \email{cgid@novonordisk.com}
   \item Kristian Troejelsgaard \email{ktqn@novonordisk.com}
   \item Steffen Falgreen Larsen \email{sffl@novonordisk.com}
-  \item VLOB (Vladimir Obucina) \email{vlob@novonordisk.com}
+  \item Vladimir Obucina \email{vlob@novonordisk.com}
 }
 
 Other contributors:

--- a/vignettes/articles/example.Rmd
+++ b/vignettes/articles/example.Rmd
@@ -1,11 +1,7 @@
 ---
 title: "Log example"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Log example}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
 ---
+
 
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(

--- a/vignettes/example.Rmd
+++ b/vignettes/example.Rmd
@@ -30,14 +30,14 @@ is created on Linux we can use the `whirl.track_files` option to automatically t
 ```{r whirl-setup}
 library(whirl)
 
-options(whirl.track_files = FALSE)
+options(whirl.track_files = TRUE)
 options(whirl.verbosity_level = "minimal")
 ```
 
 The `verbosity_level` is set to `minimal` for nicer printing in ths vignette.
 Now we are ready to execute the script:
 
-```{r run, eval=FALSE}
+```{r run}
 result <- run("example.R")
 
 print(result)
@@ -45,7 +45,7 @@ print(result)
 
 The script is now executed and you can access the logs below:
 
-```{r copy, include=FALSE, eval=FALSE}
+```{r copy, include=FALSE}
 file.copy(from = "summary.html", to = "../docs/articles")
 file.copy(from = "example_log.html", to = "../docs/articles")
 ```
@@ -53,4 +53,3 @@ file.copy(from = "example_log.html", to = "../docs/articles")
 * [View summary log](summary.html)
 * [View log for example.R](example_log.html)
 * [The saved plot1.png](plot1.png)
-

--- a/vignettes/example.Rmd
+++ b/vignettes/example.Rmd
@@ -30,7 +30,7 @@ is created on Linux we can use the `whirl.track_files` option to automatically t
 ```{r whirl-setup}
 library(whirl)
 
-options(whirl.track_files = TRUE)
+options(whirl.track_files = FALSE)
 options(whirl.verbosity_level = "minimal")
 ```
 

--- a/vignettes/example.Rmd
+++ b/vignettes/example.Rmd
@@ -37,7 +37,7 @@ options(whirl.verbosity_level = "minimal")
 The `verbosity_level` is set to `minimal` for nicer printing in ths vignette.
 Now we are ready to execute the script:
 
-```{r run}
+```{r run, eval=FALSE}
 result <- run("example.R")
 
 print(result)
@@ -45,7 +45,7 @@ print(result)
 
 The script is now executed and you can access the logs below:
 
-```{r copy, include=FALSE}
+```{r copy, include=FALSE, eval=FALSE}
 file.copy(from = "summary.html", to = "../docs/articles")
 file.copy(from = "example_log.html", to = "../docs/articles")
 ```

--- a/vignettes/whirl.Rmd
+++ b/vignettes/whirl.Rmd
@@ -3,7 +3,7 @@ title: "Execute Scripts"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Execute Scripts}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{knitr::rmarkdown_notangle}
   %\VignetteEncoding{UTF-8}
 ---
 
@@ -60,7 +60,7 @@ It is also possible to provide a character vector of several paths (either singl
 
 If the scripts have to be executed in a specific order, the `input` argument can be supplied as a list. The scripts will then be executed in the order they are listed in the list, with scripts listed in the same element being executed in parallel (if `n_workers` > 1). 
 
-```{r, eval = FALSE}
+```{r}
 # In the below example, script1.R and script2.R will be executed in parallel
 run(
   input = c("path/to/script1.R",
@@ -93,7 +93,7 @@ The list can also be supplied with names list elements.
 This can be useful during execution as some of these 'name' will be printed to the console.
 
 E.g.
-```{r, eval = FALSE}
+```{r}
 run(input = list(
   list(
     name = "Step 1", 
@@ -128,7 +128,7 @@ steps:
 In this case, the `input` argument in the `run()` function should point to the config file. 
 Assuming the config file is called `config.yaml`, the execution can be initiated as follows:
 
-```{r, eval = FALSE}
+```{r}
 run(input = "path/to/config.yaml", n_workers = 4)
 ```
 


### PR DESCRIPTION
This PR fixes some R CMD Build issues related to the vignettes:

* **whirl.Rmd** is now rendered using the `knitr::rmarkdown_notangle` Vignette engine to make sure the vignette is not rerun as an R program using `purl()`. See more in this comment: https://github.com/yihui/knitr/issues/2103#issuecomment-1059445039.

*  **example.Rmd** has been transformed to an article instead of a vignette, so that it is not build when running R CMD Build/Check commands.