### PR TITLE
fix: improve unit tests and make them compatible with CRAN

### DIFF
--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -18,12 +18,6 @@ jobs:
       NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@main
     with:
       use_local_setup_action: true
-  check-nn-version:
-    name: Check NN version
-    uses: >-
-      NovoNordisk-OpenSource/r.workflows/.github/workflows/check_nn_versions.yaml@main
-    with:
-      use_local_setup_action: true
   pkgdown:
     name: Pkgdown site
     uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,3 +53,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+SystemRequirements: Quarto command line tool
+    (<https://github.com/quarto-dev/quarto-cli>).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Logging package
-Version: 0.1.10.9001
+Version: 0.1.10.9002
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/R/run.R
+++ b/R/run.R
@@ -21,8 +21,8 @@
 #' @inheritParams whirl-options-params
 #' @return A tibble containing the execution results for all the scripts.
 #'
-
-#' @examples
+#' @examplesIf !is.null(quarto::quarto_path())
+#'
 #' # Start by copying the following three example scripts:
 #' file.copy(
 #'   from = system.file("examples", c("success.R", "warning.R", "error.R"),

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -61,6 +61,8 @@ The way the execution is logged is configurable through several options for
 e.g. the verbosity of the logs. See \link{whirl-options} on how to configure these.
 }
 \examples{
+\dontshow{if (!is.null(quarto::quarto_path())) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+
 # Start by copying the following three example scripts:
 file.copy(
   from = system.file("examples", c("success.R", "warning.R", "error.R"),
@@ -83,7 +85,7 @@ run(
   ),
   n_workers = 2
 )
-
+\dontshow{\}) # examplesIf}
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # Re-directing the logs to a sub-folder by utilizing the log_dir argument in

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -5,3 +5,12 @@ test_script <- function(script) {
     normalizePath(winslash = "/", mustWork = TRUE)
   return(script)
 }
+
+# Use to test quarto availability or version lower than - from the quarto package
+skip_if_no_quarto <- function(ver = NULL) {
+  skip_if(is.null(quarto::quarto_path()), message = "Quarto is not available")
+  skip_if(
+    quarto::quarto_version() < ver,
+    message = sprintf("Version of quarto is lower than %s: %s.", ver,  quarto::quarto_version())
+  )
+}

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,4 +1,5 @@
 test_that("All example scripts run with consistent output", {
+  skip_if_no_quarto()
   withr::with_tempdir({
     # Copy all example scripts to the temporary working directory
 

--- a/tests/testthat/test-internal_run.R
+++ b/tests/testthat/test-internal_run.R
@@ -1,4 +1,6 @@
 test_that("testing internal_run()", {
+  skip_if_no_quarto()
+
   # A config file
 
   q <- whirl_queue$new(n_workers = 2)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -10,6 +10,7 @@ expect_single_script <- function(res) {
 }
 
 test_that("Run single R script", {
+  skip_if_no_quarto()
   res <- test_script("success.R") |>
     run() |>
     expect_no_warning() |>
@@ -19,6 +20,7 @@ test_that("Run single R script", {
 })
 
 test_that("Run single python script", {
+  skip_if_no_quarto()
   res <- test_script("py_success.py") |>
     run() |>
     expect_no_warning() |>
@@ -50,6 +52,7 @@ expect_multiple_scripts <- function(res) {
 }
 
 test_that("Run multiple R scripts", {
+  skip_if_no_quarto()
   res <- test_script(c("success.R", "warning.R", "error.R")) |>
     run(n_workers = 2) |>
     expect_no_error()
@@ -58,6 +61,7 @@ test_that("Run multiple R scripts", {
 })
 
 test_that("Run multiple python scripts", {
+  skip_if_no_quarto()
   res <- test_script(c("py_success.py", "py_warning.py", "py_error.py")) |>
     run(n_workers = 2) |>
     expect_no_error()
@@ -66,12 +70,14 @@ test_that("Run multiple python scripts", {
 })
 
 test_that("Run yaml config file", {
+  skip_if_no_quarto()
   res <- test_script("_whirl.yaml") |>
     run(n_workers = 2) |>
     expect_no_error()
 })
 
 test_that("Change the log_dir to a path", {
+  skip_if_no_quarto()
   # Custom path
   custom_path <- withr::local_tempdir()
 
@@ -87,6 +93,7 @@ test_that("Change the log_dir to a path", {
 })
 
 test_that("Change the log_dir with a function", {
+  skip_if_no_quarto()
   # Custom path and copy script
   custom_path <- withr::local_tempdir()
   dir.create(file.path(custom_path, "logs"))
@@ -107,6 +114,7 @@ test_that("Change the log_dir with a function", {
 })
 
 test_that("Change the execute_dir to a path", {
+  skip_if_no_quarto()
   custom_path <- withr::local_tempdir()
   withr::local_options(whirl.execute_dir = custom_path)
 
@@ -122,6 +130,7 @@ test_that("Change the execute_dir to a path", {
 })
 
 test_that("Change the execute_dir to a function", {
+  skip_if_no_quarto()
   withr::local_options(whirl.execute_dir = \(x) dirname(x))
 
   test_script("success.R") |>

--- a/tests/testthat/test-strace.R
+++ b/tests/testthat/test-strace.R
@@ -7,19 +7,6 @@ strace_info <- function(path = "strace.log") {
   )
 }
 
-# expect_strace <- function(read, delete, write, path = "strace.log") {
-#   strace_info <- strace_info(path = path)
-
-#   strace_info$read$file |>
-#     testthat::expect_match(read)
-
-#   strace_info$delete$file |>
-#     testthat::expect_match(delete)
-
-#   strace_info$write$file |>
-#     testthat::expect_match(write)
-# }
-
 test_that("strace works", {
   skip_on_ci()
   skip_on_os(c("windows", "mac", "solaris"))
@@ -31,10 +18,6 @@ test_that("strace works", {
       p <- callr::r_session$new()
 
       start_strace(pid = p$get_pid(), file = file.path(getwd(), "strace.log"))
-
-      # No output yet
-
-      # p$run(\() 1 + 1)
 
       # Only save a file
 
@@ -65,7 +48,6 @@ test_that("strace works", {
         testthat::expect_true()
       any(grepl(x = test$delete$file, pattern = "dummy.txt")) |>
         testthat::expect_true()
-      # expect_strace("/dummy.txt$", "/dummy.txt$", "/mtcars.rds$")
 
       p$kill()
       p$finalize()

--- a/tests/testthat/test-util_queue_summary.R
+++ b/tests/testthat/test-util_queue_summary.R
@@ -20,6 +20,7 @@ test_that(
 # Test for successful creation of summary tibble
 
 test_that("Summary tibble is created successfully", {
+  skip_if_no_quarto()
   q <- whirl_queue$new(n_workers = 2)
 
   test_script(c("success.R", "py_success.py")) |>

--- a/tests/testthat/test-whirl_r_session.R
+++ b/tests/testthat/test-whirl_r_session.R
@@ -1,4 +1,5 @@
 test_that("interactive whirl R session components not tested in run", {
+  skip_if_no_quarto()
   p <- whirl_r_session$new(verbosity_level = "minimal")
 
   p$print() |>


### PR DESCRIPTION
Goal of this PR is to make sure our unit tests will run on CRAN.
To do this I made the following changes:

1. All tests using `run()` are skipped if Quarto is not available 
2. `run()` examples are also skipped if Quarto is not available
3. Quarto added as system requirement similar to in [{quarto}](https://github.com/quarto-dev/quarto-r/blob/main/DESCRIPTION)

Note they will still be checked on our own internal CI. Here I removed the workflow using locked versions of R since {zephyr} was not available at the time.

This version of {whirl} has been run through the R validation hub servers to test if it works:
https://github.com/r-hub2/convenient-moose-whirl/actions/runs/13813756287
