### PR TITLE
fix/private finalize methods

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/testthat/scripts/*.html linguist-generated

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Logging package
-Version: 0.1.10.9003
+Version: 0.1.10.9004
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),
@@ -30,7 +30,7 @@ Imports:
     knitr,
     purrr,
     quarto,
-    R6,
+    R6 (>= 2.4.0),
     renv,
     reticulate,
     rlang,

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -296,7 +296,7 @@ wq_next_step <- function(self, private, wid) {
       purrr::pluck(private$.queue, "status", id_script) <-
         purrr::pluck(private$.queue, "result", id_script, "status", "status")
 
-      session$finalize()
+      #session$kill() # kill process
 
       purrr::pluck(private$.workers, "session", wid) <- NULL
       purrr::pluck(private$.workers, "active", wid) <- FALSE
@@ -312,4 +312,5 @@ wq_run <- function(scripts, self) {
   self$
     push(scripts)$
     wait() # nolint
+  on.exit(gc()) # finalizes used whirl_r_sessions - clenup temp folders
 }

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -47,11 +47,6 @@ whirl_r_session <- R6::R6Class(
       )
     },
 
-    #' @description Finalize the whirl R session
-    finalize = \() {
-      wrs_finalize(self, private, super)
-    },
-
     #' @description Print the whirl R session
     #' @return [invisible] self
     print = \() {
@@ -123,6 +118,10 @@ whirl_r_session <- R6::R6Class(
     }
   ),
   private = list(
+    #' @description Finalize the whirl R session
+    finalize = \() {
+      wrs_finalize(self, private, super)
+    },
     verbosity_level = NULL,
     wd = NULL,
     track_files = NULL,
@@ -196,9 +195,12 @@ wrs_initialize <- function(
       file = file.path(private$wd, "strace.log")
     )
   }
+
+  zephyr::msg_debug("Started session with pid={.field {self$get_pid()}} and wd={.file {private$wd}}")
 }
 
 wrs_finalize <- function(self, private, super) {
+  zephyr::msg_debug("Finalizing session with pid={.field {self$get_pid()}} and wd={.file {private$wd}}")
   super$run(func = setwd, args = list(dir = getwd()))
   unlink(private$wd, recursive = TRUE)
   super$finalize()

--- a/tests/testthat/test-strace.R
+++ b/tests/testthat/test-strace.R
@@ -50,7 +50,6 @@ test_that("strace works", {
         testthat::expect_true()
 
       p$kill()
-      p$finalize()
     },
     tmpdir = getwd()
   )


### PR DESCRIPTION
- **fix: not count html log for unit tests as code**
- **fix: make `finalize()` methods private**
