### PR TITLE
fix: limit imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
     #     args: [--style_pkg=styler, --style_fun=tidyverse_style]
     -   id: roxygenize
         additional_dependencies:
-          - checkmate
           - dplyr
           - ggplot2
           - httr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     knitr,
     quarto,
     R6 (>= 2.4.0),
-    renv,
     reticulate,
     rlang,
     sessioninfo,
@@ -40,6 +39,7 @@ Imports:
     yaml,
     zephyr (>= 0.1.1)
 Suggests: 
+    renv,
     testthat (>= 3.0.0),
     usethis
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Logging package
-Version: 0.1.10.9005
+Version: 0.1.10.9006
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     callr,
     cli,
     dplyr,
-    ggplot2,
     jsonlite,
     kableExtra,
     knitr,
@@ -39,6 +38,7 @@ Imports:
     yaml,
     zephyr (>= 0.1.1)
 Suggests: 
+    ggplot2,
     renv,
     testthat (>= 3.0.0),
     usethis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Depends:
     R (>= 4.1)
 Imports: 
     callr,
-    checkmate,
     cli,
     dplyr,
     ggplot2,

--- a/R/approvedpkgs.R
+++ b/R/approvedpkgs.R
@@ -144,6 +144,7 @@ check_approved <- function(
 
 #' @noRd
 create_approval_plot <- function(data) {
+  rlang::check_installed("ggplot2")
   row.names(data) <- NULL
 
   data$grpvar <- ifelse(

--- a/R/custom_logging.R
+++ b/R/custom_logging.R
@@ -39,9 +39,8 @@ write_to_log <- function(
     type = c("read", "write", "delete"),
     log = Sys.getenv("WHIRL_LOG_MSG")) {
   type <- rlang::arg_match(type)
-  checkmate::assert_string(type)
-  checkmate::assert_string(file)
-  checkmate::assert_string(log)
+  stopifnot(rlang::is_string(file))
+  stopifnot(rlang::is_string(log))
 
   x <- log_df(
     type = type,

--- a/R/renv.R
+++ b/R/renv.R
@@ -3,7 +3,7 @@
 
 renv_status <- function() {
   rlang::check_installed("renv")
-  
+
   msg <- utils::capture.output(status <- renv::status())
 
   structure(

--- a/R/renv.R
+++ b/R/renv.R
@@ -2,6 +2,8 @@
 #' @noRd
 
 renv_status <- function() {
+  rlang::check_installed("renv")
+  
   msg <- utils::capture.output(status <- renv::status())
 
   structure(

--- a/R/run.R
+++ b/R/run.R
@@ -82,6 +82,9 @@ run <- function(
 
   # Check suggest imports if they are needed
   if (check_renv) rlang::check_installed("renv")
+  if (!is.null(approved_pkgs_folder) || !is.null(approved_pkgs_url)) {
+    rlang::check_installed("ggplot2")
+  }
 
   # Message when initiating
   d <- NULL

--- a/R/run.R
+++ b/R/run.R
@@ -80,6 +80,9 @@ run <- function(
   approved_pkgs_folder <- zephyr::get_option("approved_pkgs_folder")
   approved_pkgs_url <- zephyr::get_option("approved_pkgs_url")
 
+  # Check suggest imports if they are needed
+  if (check_renv) rlang::check_installed("renv")
+
   # Message when initiating
   d <- NULL
   zephyr::msg_verbose(

--- a/README.Rmd
+++ b/README.Rmd
@@ -110,4 +110,4 @@ For more information about how to customize the the execution and the logging fo
 * `run()`: For further information on how to call it.
 * `vignette("whirl")`: For a more in depth explanation, and more advanced usage.
 * `vignette("articles/example")`: With a simple example, including the created log.
-* `whirl-options`: On how to change the default behavior of whirl.
+* [whirl-options](https://novonordisk-opensource.github.io/whirl/reference/whirl-options.html): On how to change the default behavior of whirl.

--- a/README.Rmd
+++ b/README.Rmd
@@ -110,4 +110,4 @@ For more information about how to customize the the execution and the logging fo
 * `run()`: For further information on how to call it.
 * `vignette("whirl")`: For a more in depth explanation, and more advanced usage.
 * `vignette("articles/example")`: With a simple example, including the created log.
-* `options()`: On how to change the default behavior of whirl.
+* `whirl-options`: On how to change the default behavior of whirl.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,5 @@ logging for your needs see the following:
   advanced usage.
 - `vignette("articles/example")`: With a simple example, including the
   created log.
-- `whirl-options()`: On how to change the default behavior of whirl.
+- [whirl-options](https://novonordisk-opensource.github.io/whirl/reference/whirl-options.html):
+  On how to change the default behavior of whirl.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ logging for your needs see the following:
   advanced usage.
 - `vignette("articles/example")`: With a simple example, including the
   created log.
-- `options()`: On how to change the default behavior of whirl.
+- `whirl-options()`: On how to change the default behavior of whirl.


### PR DESCRIPTION
Get's us below 20 direct imports by doing the following changes:

- fix: remove checkmate since it was only used in one function
- fix: only use renv as a suggested import
- fix: only use ggplot2 as a suggested import
- fix: dead link to package options in readme
