### PR TITLE
fix: Do not show files if files are not tracked

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.2.0.9004
+Version: 0.2.0.9005
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/R/custom_logging.R
+++ b/R/custom_logging.R
@@ -62,8 +62,11 @@ write_to_log <- function(
 }
 
 #' @noRd
-read_from_log <- function(log = Sys.getenv("WHIRL_LOG_MSG")) {
+read_from_log <- function(log = Sys.getenv("WHIRL_LOG_MSG"), track_files) {
   if (log == "" || !file.exists(log)) {
+    if (!track_files) {
+      return(NULL)
+    }
     return(log_df())
   }
 
@@ -85,12 +88,14 @@ log_df <- function(type = character(), file = character()) {
 
 #' @noRd
 split_log <- function(x, types = c("read", "write", "delete")) {
-  # Split in a tibble for each type of output
+  if (is.null(x)) {
+    return(NULL)
+  }
 
+  # Split in a tibble for each type of output
   x <- split(x[c("time", "file")], x$type)
 
   # Add empty table for types not reported
-
   out <- vector(mode = "list", length = length(types)) |>
     rlang::set_names(types)
 

--- a/R/log.R
+++ b/R/log.R
@@ -9,13 +9,14 @@ read_info <- function(
   environment,
   options,
   python = NULL,
-  approved_packages = NULL
+  approved_packages = NULL,
+  track_files = FALSE
 ) {
   info <- list(
     script = readRDS(script),
     status = get_status(md = md, start = start),
     files = log |>
-      read_from_log() |>
+      read_from_log(track_files = track_files) |>
       split_log(),
     session = read_session_info(
       file = session,

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -360,6 +360,7 @@ wrs_create_log <- function(self, private, super) {
         title = private$current_script,
         approved_packages = private$approved_packages,
         with_library_paths = .libPaths(),
+        track_files = private$track_files,
         tmpdir = normalizePath(private$wd)
       ),
       execute_dir = normalizePath(".")

--- a/inst/documents/log.qmd
+++ b/inst/documents/log.qmd
@@ -9,6 +9,7 @@ params:
   title: 'dev'
   with_library_paths: library_paths
   approved_packages: NULL
+  track_files: FALSE
   tmpdir: '.'
 format:
   html:
@@ -68,7 +69,8 @@ result <- whirl:::read_info(
   environment = file.path(params$tmpdir, "environment.rds"),
   options = file.path(params$tmpdir, "options.rds"),
   python = file.path(params$tmpdir, "python_imports.json"),
-  approved_packages = params$approved_packages
+  approved_packages = params$approved_packages,
+  track_files = isTRUE(as.logical(params$track_files))
 )
 
 saveRDS(


### PR DESCRIPTION
## Summary
Do not show the tables of used and creates files in the log, if `track_files = FALSE` and no files are tracked using e.g. the `log_read()` utility.

## Checklist
- [ ] PR linked to issue descripting the bug or feature request being addressed
- [ ] Code changes have been tested
- [ ] Documentation has been updated, if applicable
- [ ] All automated tests pass
- [ ] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge
