### PR TITLE
feat: improve error message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: PR Template
-about: Template for PRs.
-title: "[PR] PR name"
-labels: ''
-assignees: ''
----
-
 ## Summary
 (Summary of made changes with explanation of what and why)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.0.9001
+Version: 0.3.0.9002
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.0
+Version: 0.3.0.9001
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# whirl dev
+
+* Improved error handling when the log cannot be created.
+
 # whirl 0.3.0
 
 * Add `write_biocompute()` to create [BioCompute Objects](https://www.biocomputeobject.org/) containing the logs in a standardized JSON format.

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -259,7 +259,7 @@ wq_poll <- function(
   for (i in i_active) {
     p <- private$.workers$session[[i]]$poll(timeout = i_timeout)
     if (p == "ready") {
-      private$.workers$session[[i]]$read()
+      private$.workers$session[[i]]$check_status()
     }
     if (private$.workers$session[[i]]$get_state() == "idle") {
       wq_next_step(self, private, i)

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -17,7 +17,7 @@ whirl_queue <- R6::R6Class(
     initialize = \(
       # jscpd:ignore-start
       n_workers = zephyr::get_option("n_workers", "whirl"),
-      verbosity_level = zephyr::get_option("verbosity_level", "whirl"),
+      verbosity_level = zephyr::get_verbosity_level("whirl"),
       check_renv = zephyr::get_option("check_renv", "whirl"),
       track_files = zephyr::get_option("track_files", "whirl"),
       out_formats = zephyr::get_option("out_formats", "whirl"),
@@ -195,7 +195,7 @@ wq_add_queue <- function(self, private, scripts, tag, status) {
     # Check if the directory exists
     unique_folders <- unique(folder)
     if (any(!file.exists(unique_folders))) {
-      missing <- unique_folders[!file.exists(unique_folders)]  # nolint: object_usage_linter
+      missing <- unique_folders[!file.exists(unique_folders)] # nolint: object_usage_linter
       cli::cli_abort(
         "Logs cannot be saved because {.val {missing}} does not exist"
       )
@@ -258,7 +258,9 @@ wq_poll <- function(
   i_timeout <- round(timeout / length(i_active))
   for (i in i_active) {
     p <- private$.workers$session[[i]]$poll(timeout = i_timeout)
-    if (p == "ready") private$.workers$session[[i]]$read()
+    if (p == "ready") {
+      private$.workers$session[[i]]$read()
+    }
     if (private$.workers$session[[i]]$get_state() == "idle") {
       wq_next_step(self, private, i)
     }

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -266,9 +266,14 @@ wrs_wait <- function(timeout, self, private, super) {
 wrs_check_status <- function(self, private, super) {
   status <- super$read()
   if (!is.null(status$error)) {
-    status$error |>
-      as.character() |>
-      rlang::abort()
+    cli::cli_abort(
+      c(
+        "Could not run {.file {private$current_script}}",
+        "x" = "Error from {.fn quarto::quarto_render}:",
+        strsplit(x = status$stdout, split = "\n") |>
+          unlist()
+      )
+    )
   }
   return(invisible(status))
 }

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -269,7 +269,7 @@ wrs_check_status <- function(self, private, super) {
     cli::cli_abort(
       c(
         "Could not run {.file {private$current_script}}",
-        "x" = "Error from {.fn quarto::quarto_render}:",
+        "i" = "Error from {.fn quarto::quarto_render}:",
         strsplit(x = status$stdout, split = "\n") |>
           unlist()
       )

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -14,7 +14,7 @@ whirl_r_session <- R6::R6Class(
     #' @return A [whirl_r_session] object
     initialize = \(
       # jscpd:ignore-start
-      verbosity_level = zephyr::get_option("verbosity_level", "whirl"),
+      verbosity_level = zephyr::get_verbosity_level("whirl"),
       check_renv = zephyr::get_option("check_renv", "whirl"),
       track_files = zephyr::get_option("track_files", "whirl"),
       out_formats = zephyr::get_option("out_formats", "whirl"),

--- a/tests/testthat/scripts/render_error.R
+++ b/tests/testthat/scripts/render_error.R
@@ -1,0 +1,3 @@
+# This script will always error in the logging process due to
+# Quarto params being deleted.
+rm(list = ls())

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -1,0 +1,7 @@
+test_that("quarto error", {
+  test_script("render_error.R") |>
+    run(summary_file = NULL) |>
+    expect_error(
+      regexp = "object 'params' not found"
+    )
+})


### PR DESCRIPTION
## Summary
Improved error message when `whirl::run()` fails.

## Changes Made
- Improved error handling when the log cannot be created.
- `wrs_check_status()` is now used correctly in the `whirl_queue`, and error messages from Quarto is carried over for easier debugging
- `verbosity_level` defaults for both `whirl_queue` and `whirl_r_session` have been updated to use `zephyr::get_verbosity_level("whirl"`) for easier development 
- Removed header in Pull Request template since it is annoying to fill out and rendering of it is not useful.

## Testing
- Added test to detect an error when rendering the Quarto log (`dummy.qmd`) in `test/testthat/test-errors.R`

## Checklist
- [x] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
