### PR TITLE
fix: no warning when scripts are missing a final EOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ bco.json
 *_log.(html|json|md)
 _parametrics.yml
 _whirl.yml
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.1
+Version: 0.3.1.9000
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# whirl dev
+
+* Fixed so no warnings are given when scripts are missing a final EOL ([#206](https://github.com/NovoNordisk-OpenSource/whirl/issues/206))
+
 # whirl 0.3.1
 
 * Improved error handling when the log cannot be created.

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -262,7 +262,7 @@ wrs_log_script <- function(script, self, private, super) {
       md5sum = private$current_script |> # Devskim: ignore DS126858
         tools::md5sum() |> # Devskim: ignore DS126858
         unname(),
-      content = readLines(private$current_script) |>
+      content = readLines(con = private$current_script, warn = FALSE) |>
         paste0(collapse = "\n")
     ),
     file = file.path(private$wd, "script.rds")

--- a/inst/documents/dummy.qmd
+++ b/inst/documents/dummy.qmd
@@ -31,7 +31,7 @@ file.path(params$tmpdir, "parent_options.rds") |>
 # Conversion is done to avoid problems caused by the warnings thrown
 # by knitr::knit(), see e.g. issue #151
 knitr::spin(
-  text = readLines(params$script),
+  text = readLines(con = params$script, warn = FALSE),
   knit = FALSE,
   format = "qmd"
 ) |>


### PR DESCRIPTION
## Summary
Fixed so that `readLines()` are called with `warn = FALSE` when reading in the script.
Otherwise users are shows an irrelevant warning if they are missing a final empty line in the script.

## Changes Made
- Updated `wrs_log_script()`
- Updated `dummy.qmd`

## Testing
- No additional tests needed.
- Verified issue no longer exists using the example in #206 

## Checklist
- [x] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
