### PR TITLE
fix: minimum version for reticulate in tests

### DIFF
--- a/tests/testthat/test-python.R
+++ b/tests/testthat/test-python.R
@@ -2,6 +2,7 @@ test_that("python dependencies found correctly", {
   skip_on_cran()
   skip_if_no_quarto()
   skip_if_no_python()
+  skip_if_not_installed(pkg = "reticulate", minimum_version = "1.41.0")
 
   reticulate::py_require("pandas")
   reticulate::py_require("numpy")
@@ -42,7 +43,7 @@ test_that("parse_pip_list() is consistent", {
   skip_on_cran()
   skip_if_no_python()
 
-  system("python3 -m pip list -v", intern = TRUE) |>
+  system("python -m pip list -v", intern = TRUE) |>
     parse_pip_list() |>
     expect_s3_class("data.frame") |>
     expect_named(c("package", "version", "path", "installer")) |>


### PR DESCRIPTION
## Summary
Added minimum required reticulate version in python unit test.
Needed to skip test on older R installations, where `py_require()` is not available.
See https://rstudio.github.io/reticulate/news/index.html#reticulate-1410.

## Testing
- Every test is still a success

## Checklist
- [ ] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
