### PR TITLE
feat: release v0.3.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@ summary.html
 ^uv.lock$
 ^pyproject.toml$
 ^.venv
+^.claude

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.1.9000
+Version: 0.3.2
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# whirl dev
+# whirl 0.3.2
 
-* Fixed bug where warnings were given when scripts are missing a final EOL (#206)
-* Fixed bug so no warning is shown when saving `options()` to the temp folder used by whirl (#206)
-* Fixed so Quarto is started with the right renv library paths when using renv (#215)
+* Fixed bug where warnings were given when scripts are missing a final EOL (#206).
+* Fixed bug so no warning is shown when saving `options()` to the temp folder used by whirl (#206).
+* Fixed so Quarto is started with the right renv library paths when using renv (#215).
 
 # whirl 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,9 @@
 # whirl 0.3.2
 
-* Fixed bug where warnings were given when scripts are missing a final EOL (#206)
-* Fixed bug so no warning is shown when saving `options()` to the temp folder used by whirl (#206)
-* Fixed so Quarto is started with the right renv library paths when using renv (#215)
-* Refactored log.qmd to remove read_log.
-* Added new `with_options` argument to `run()`. This is the only options being set in the child sessions now. (#187)
+* Fixed bug where warnings were given when scripts are missing a final EOL (#206).
+* Fixed bug so no warning is shown when saving options to the temp folder used by whirl (#206).
+* Fixed so Quarto is started with the right renv library paths when using renv (#215).
+* Added new `with_options` argument to `run()`. This is the only options being set in the child sessions now. (#187).
 
 # whirl 0.3.1
 

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -196,7 +196,6 @@ wrs_finalize <- function(self, private, super) {
   zephyr::msg_debug(
     "Finalizing session with pid={.field {self$get_pid()}} and tmpdir={.file {self$tmpdir}}" # nolint: line_length_linter
   )
-  super$run(func = setwd, args = list(dir = getwd()))
   unlink(self$tmpdir, recursive = TRUE)
   super$finalize()
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,8 +2,5 @@
 
 0 errors | 0 warnings | 1 note
 
-* Patch update improving the logs.
-* Removed `verbosity_level` argument to `run()` since it is now completely controlled
-by zephyr options (see `help("whirl-options")`). No reverse dependencies.
-* [Check result errors](https://cran.r-project.org/web/checks/check_results_whirl.html)
-should be fixed in [#197](https://github.com/NovoNordisk-OpenSource/whirl/pull/197)
+* Patch release adressing a few bugs.
+

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,5 +2,5 @@
 
 0 errors | 0 warnings | 1 note
 
-* Patch release adressing a few bugs.
+* Patch release addressing a few bugs.
 

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,4 +1,5 @@
 test_that("All example scripts run with consistent output", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   tmpdir <- withr::local_tempdir()


### PR DESCRIPTION
## Summary
Released version 0.3.2 of whirl to CRAN.
See https://cran.r-project.org/package=whirl.

## Changes
- Streamlined entries in README.
- Added .claude to `.Rbuildignore` for local R CMD Checks
- Removed code changing the working directory of the whirl_r_session when finalized. Was accidently reintroduced in previous merge.
- Skipped `test-examples.R` on CRAN due to tests running more than 10 minutes.

## Checklist
- [x] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
