### PR TITLE
feat: support named list syntax for step naming in run()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,6 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: Quarto command line tool
     (<https://github.com/quarto-dev/quarto-cli>).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.2
+Version: 0.3.2.9000
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# whirl (development version)
+
 # whirl 0.3.2
 
 * Fixed bug where warnings were given when scripts are missing a final EOL (#206).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # whirl (development version)
 
+* Added support for named list syntax to specify step names in `run()` (#201).
+
 # whirl 0.3.2
 
 * Fixed bug where warnings were given when scripts are missing a final EOL (#206).

--- a/R/enrich_input.R
+++ b/R/enrich_input.R
@@ -38,9 +38,12 @@ enrich_input <- function(
   paths <- list()
   for (i in seq_along(got)) {
     # Identify the step names - if none, then create a default name
-    check_name <- any(grepl("name", names(got[[i]])))
-    if (check_name) {
-      names[[i]] <- got[[i]][[which(grepl("name", names(got[[i]])))]]
+    outer_name <- names(got)[i]
+
+    if (!is.null(outer_name) && nzchar(outer_name)) {
+      names[[i]] <- outer_name
+    } else if (any(grepl("name", names(got[[i]])))) {
+      names[[i]] <- got[[i]][[grep("name", names(got[[i]]))]]
     } else {
       names[[i]] <- paste0("Step ", i)
     }
@@ -48,7 +51,7 @@ enrich_input <- function(
     # Identify the paths
     check_path <- any(grepl("path", names(got[[i]])))
     if (check_path) {
-      paths[[i]] <- got[[i]][[which(grepl("path", names(got[[i]])))]]
+      paths[[i]] <- got[[i]][[grep("path", names(got[[i]]))]]
     } else {
       paths[[i]] <- got[[i]]
     }
@@ -59,6 +62,9 @@ enrich_input <- function(
     input = paths,
     root_dir = root_dir
   )
+
+  # Flatten nested lists to character vectors
+  paths <- lapply(paths, function(x) unlist(x, use.names = FALSE))
 
   # If input include one or more directories
   paths_is_dir <- unlist(paths)

--- a/R/enrich_input.R
+++ b/R/enrich_input.R
@@ -20,7 +20,7 @@ enrich_input <- function(
   if (is_config_file && length(input) == 1) {
     root_dir <- dirname(input)
     config_whirl <- yaml::read_yaml(file = input, eval.expr = TRUE)
-    got <- config_whirl$"steps"
+    got <- config_whirl[["steps"]]
   } else {
     root_dir <- getwd()
   }
@@ -42,16 +42,15 @@ enrich_input <- function(
 
     if (!is.null(outer_name) && nzchar(outer_name)) {
       names[[i]] <- outer_name
-    } else if (any(grepl("name", names(got[[i]])))) {
-      names[[i]] <- got[[i]][[grep("name", names(got[[i]]))]]
+    } else if ("name" %in% names(got[[i]])) {
+      names[[i]] <- got[[i]][["name"]]
     } else {
       names[[i]] <- paste0("Step ", i)
     }
 
     # Identify the paths
-    check_path <- any(grepl("path", names(got[[i]])))
-    if (check_path) {
-      paths[[i]] <- got[[i]][[grep("path", names(got[[i]]))]]
+    if ("paths" %in% names(got[[i]])) {
+      paths[[i]] <- got[[i]][["paths"]]
     } else {
       paths[[i]] <- got[[i]]
     }

--- a/R/mdformats.R
+++ b/R/mdformats.R
@@ -8,7 +8,7 @@ mdformats <- function(script, log_html, mdfmt, self, out_dir) {
 
   supported_formats <- list_pandoc_output_formats()
   unsupported_formats <- setdiff(mdfmt, supported_formats)
-  if (any(!mdfmt %in% supported_formats)) {
+  if (!all(mdfmt %in% supported_formats)) {
     cli::cli_abort(
       "Output format{?s} {.code {unsupported_formats}} not supported by your pandoc installation"
     )

--- a/R/run.R
+++ b/R/run.R
@@ -12,7 +12,8 @@
 #'   scripts, or files in a folder using regular expression, or to to a whirl
 #'   config file. The input can also be structured in a list where each element
 #'   will be executed sequentially, while scripts within each element can be
-#'   executed in parallel.
+#'   executed in parallel. Named list elements set step names shown during
+#'   execution (e.g. `list("Step 1" = "script.R")`).
 #' @param steps An optional argument that can be used if only certain steps
 #'   within a config files (or list) is to be executed. Should be equivalent to
 #'   the names of the steps found in the config file. If kept as NULL (default)
@@ -45,6 +46,14 @@
 #'   list(
 #'     file.path(tempdir(), c("success.R", "warning.R")),
 #'     file.path(tempdir(), "error.R")
+#'   )
+#' )
+#'
+#' # Name the steps using named list syntax:
+#' run(
+#'   list(
+#'     "Step 1" = file.path(tempdir(), c("success.R", "warning.R")),
+#'     "Step 2" = file.path(tempdir(), "error.R")
 #'   )
 #' )
 #'

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -13,7 +13,7 @@ whirl_queue <- R6::R6Class(
   public = list(
     #' @inheritParams options_params
     #' @description Initialize the new whirl_queue
-    #' @return A [whirl_queue] object
+    #' @return A `whirl_queue` object
     initialize = \(
       # jscpd:ignore-start
       n_workers = zephyr::get_option("n_workers", "whirl"),

--- a/R/whirl_queue.R
+++ b/R/whirl_queue.R
@@ -185,7 +185,7 @@ wq_add_queue <- function(self, private, scripts, tag, status) {
     folder <- private$log_dir(scripts)
     # Check if the directory exists
     unique_folders <- unique(folder)
-    if (any(!file.exists(unique_folders))) {
+    if (!all(file.exists(unique_folders))) {
       missing <- unique_folders[!file.exists(unique_folders)] # nolint: object_usage_linter
       cli::cli_abort(
         "Logs cannot be saved because {.val {missing}} does not exist"

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -11,7 +11,7 @@ whirl_r_session <- R6::R6Class(
   public = list(
     #' @description Initialize the new whirl R session
     #' @inheritParams options_params
-    #' @return A [whirl_r_session] object
+    #' @return A `whirl_r_session` object
     initialize = \(
       # jscpd:ignore-start
       check_renv = zephyr::get_option("check_renv", "whirl"),

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -21,7 +21,8 @@ run(
 scripts, or files in a folder using regular expression, or to to a whirl
 config file. The input can also be structured in a list where each element
 will be executed sequentially, while scripts within each element can be
-executed in parallel.}
+executed in parallel. Named list elements set step names shown during
+execution (e.g. \code{list("Step 1" = "script.R")}).}
 
 \item{steps}{An optional argument that can be used if only certain steps
 within a config files (or list) is to be executed. Should be equivalent to
@@ -61,7 +62,7 @@ e.g. the verbosity of the logs.
 See \link{whirl-options} on how to configure these.
 }
 \examples{
-\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
 # Copy example scripts:
 file.copy(
   from = system.file("examples", c("success.R", "warning.R", "error.R"),
@@ -84,6 +85,14 @@ run(
   list(
     file.path(tempdir(), c("success.R", "warning.R")),
     file.path(tempdir(), "error.R")
+  )
+)
+
+# Name the steps using named list syntax:
+run(
+  list(
+    "Step 1" = file.path(tempdir(), c("success.R", "warning.R")),
+    "Step 2" = file.path(tempdir(), "error.R")
   )
 )
 

--- a/tests/testthat/test-enrich_input.R
+++ b/tests/testthat/test-enrich_input.R
@@ -74,3 +74,36 @@ test_that("Enrich input works as expected", {
     vapply(FUN = \(x) x$name, FUN.VALUE = character(1)) |>
     expect_match(regexp = format(Sys.Date()))
 })
+
+test_that("Named list syntax sets step names", {
+  success <- test_script("success.R")
+  error <- test_script("error.R")
+
+  # Named character element
+  enriched <- enrich_input(list("Step A" = success))
+  expect_equal(enriched[[1]]$name, "Step A")
+  expect_equal(enriched[[1]]$paths, success)
+
+  # Named list with unnamed elements
+  enriched <- enrich_input(list("Step B" = list(success)))
+  expect_equal(enriched[[1]]$name, "Step B")
+  expect_equal(enriched[[1]]$paths, success)
+
+  # Named list with named sub-elements (sub-names stripped by read_glob)
+  enriched <- enrich_input(
+    list("Step C" = list("Sub A" = success, "Sub B" = error))
+  )
+  expect_equal(enriched[[1]]$name, "Step C")
+  expect_equal(enriched[[1]]$paths, c(success, error))
+
+  # Mixed old and new syntax
+  enriched <- enrich_input(list(
+    "New Style" = success,
+    list(name = "Old Style", paths = error)
+  ))
+  expect_length(enriched, 2)
+  expect_equal(enriched[[1]]$name, "New Style")
+  expect_equal(enriched[[1]]$paths, success)
+  expect_equal(enriched[[2]]$name, "Old Style")
+  expect_equal(enriched[[2]]$paths, error)
+})

--- a/vignettes/whirl.Rmd
+++ b/vignettes/whirl.Rmd
@@ -91,21 +91,15 @@ run(
 )
 ```
 
-The list can also be supplied with names list elements. 
-This can be useful during execution as some of these 'name' will be printed to the console.
+The list can also be supplied with named elements to label each step.
+These names will be printed to the console during execution.
 
 E.g.
 ```{r}
 run(
   input = list(
-    list(
-      name = "Step 1",
-      paths = c("path/to/script1.R", "path/to/script2.R")
-    ),
-    list(
-      name = "Step 2",
-      paths = c("path/to/script3.R", "path/to/script4.R")
-    )
+    "Step 1" = c("path/to/script1.R", "path/to/script2.R"),
+    "Step 2" = c("path/to/script3.R", "path/to/script4.R")
   ),
   n_workers = 2
 )


### PR DESCRIPTION
## Summary

Support named list syntax (`list("Step 1" = expr(...))`) as an alternative to the verbose `list(name = "Step 1", paths = expr(...))` for step naming in `run()`.

Closes #201

## Changes Made
- Add named list detection and conversion logic in `enrich_input.R`
- Update `run()` roxygen documentation with named list syntax examples
- Add vignette documentation for the new syntax
- Add `NEWS.md` entry
- Simplify negated logical conditions across the codebase (highlighted by jarl linter)

## Testing
- Added unit tests for named list syntax in `test-enrich_input.R`
- All existing tests pass

## Checklist
- [x] PR linked to issue describing the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge