### PR TITLE
feat: add skip_after option to stop execution on error or warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.2.9000
+Version: 0.3.2.9001
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.2.9001
+Version: 0.3.2.9002
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # whirl (development version)
 
+* Added `skip_after` option to skip remaining steps after an error or warning (#202).
 * Added support for named list syntax to specify step names in `run()` (#201).
 
 # whirl 0.3.2

--- a/R/internal_run.R
+++ b/R/internal_run.R
@@ -36,8 +36,8 @@ internal_run <- function(input, steps, queue, level) {
         level = level + 1
       )
     } else if (
-      zephyr::get_option("stop_on") != "never" &&
-        any(queue$queue$status %in% zephyr::get_option("stop_on"))
+      !identical(zephyr::get_option("skip_after", "whirl"), "never") &&
+        any(queue$queue$status %in% zephyr::get_option("skip_after", "whirl"))
     ) {
       queue$skip(scripts = files, tag = name)
       zephyr::msg_verbose(message = "\n", msg_fun = cli::cli_verbatim)

--- a/R/internal_run.R
+++ b/R/internal_run.R
@@ -39,6 +39,13 @@ internal_run <- function(input, steps, queue, level) {
       !identical(zephyr::get_option("skip_after", "whirl"), "never") &&
         any(queue$queue$status %in% zephyr::get_option("skip_after", "whirl"))
     ) {
+      for (file in files) {
+        wrs_report_status(
+          status = "skipped",
+          script = file,
+          logs = character(0)
+        )
+      }
       queue$skip(scripts = files, tag = name)
       zephyr::msg_verbose(message = "\n", msg_fun = cli::cli_verbatim)
     } else {

--- a/R/internal_run.R
+++ b/R/internal_run.R
@@ -14,10 +14,7 @@
 #' @inheritParams options_params
 #' @return A tibble containing the execution results for all the scripts.
 #' @noRd
-internal_run <- function(input,
-                         steps,
-                         queue,
-                         level) {
+internal_run <- function(input, steps, queue, level) {
   # Enrich the input with "name" and "path" elements
   enriched <- enrich_input(input, steps)
 
@@ -38,8 +35,13 @@ internal_run <- function(input,
         queue = queue,
         level = level + 1
       )
+    } else if (
+      zephyr::get_option("stop_on") != "never" &&
+        any(queue$queue$status %in% zephyr::get_option("stop_on"))
+    ) {
+      queue$skip(scripts = files, tag = name)
+      zephyr::msg_verbose(message = "\n", msg_fun = cli::cli_verbatim)
     } else {
-      # Execute the scripts
       queue$run(scripts = files, tag = name)
       zephyr::msg_verbose(message = "\n", msg_fun = cli::cli_verbatim)
     }

--- a/R/render_summary.R
+++ b/R/render_summary.R
@@ -77,11 +77,11 @@ knit_print_whirl_summary_info <- function(x, path_rel_start, ...) {
       file.path()
   }
 
-  hold$Hyperlink <- paste0(sprintf(
-    '<a href="%s" target="_blank">%s</a>',
-    formatted,
-    "HTML Log"
-  ))
+  hold$Hyperlink <- ifelse(
+    hold$Hyperlink == "",
+    "",
+    sprintf('<a href="%s" target="_blank">%s</a>', formatted, "HTML Log")
+  )
 
   knitr::kable(hold, format = "html", escape = FALSE) |>
     kableExtra::column_spec(

--- a/R/render_summary.R
+++ b/R/render_summary.R
@@ -95,7 +95,7 @@ knit_print_whirl_summary_info <- function(x, path_rel_start, ...) {
           ifelse(
             hold[["Status"]] == "success",
             "#ebf5f1",
-            ifelse(hold[["Status"]] == "skip", "#94CBFF", "white")
+            ifelse(hold[["Status"]] == "skipped", "#94CBFF", "white")
           )
         )
       )

--- a/R/run.R
+++ b/R/run.R
@@ -80,7 +80,8 @@ run <- function(
   track_files = zephyr::get_option("track_files", "whirl"),
   out_formats = zephyr::get_option("out_formats", "whirl"),
   log_dir = zephyr::get_option("log_dir", "whirl"),
-  with_options = zephyr::get_option("with_options", "whirl")
+  with_options = zephyr::get_option("with_options", "whirl"),
+  stop_on = zephyr::get_option("stop_on", "whirl")
 ) {
   # Additional Settings
   track_files_discards <- zephyr::get_option("track_files_discards") |>

--- a/R/run.R
+++ b/R/run.R
@@ -81,7 +81,7 @@ run <- function(
   out_formats = zephyr::get_option("out_formats", "whirl"),
   log_dir = zephyr::get_option("log_dir", "whirl"),
   with_options = zephyr::get_option("with_options", "whirl"),
-  stop_on = zephyr::get_option("stop_on", "whirl")
+  skip_after = zephyr::get_option("skip_after", "whirl")
 ) {
   # Additional Settings
   track_files_discards <- zephyr::get_option("track_files_discards") |>
@@ -90,7 +90,11 @@ run <- function(
 
   # Overwrite options locally if supplied directly
   withr::local_options(.new = list(whirl.with_options = with_options))
-  withr::local_options(.new = list(whirl.stop_on = stop_on))
+
+  if (skip_after == "warning") {
+    skip_after <- c("warning", "error")
+  }
+  withr::local_options(.new = list(whirl.skip_after = skip_after))
 
   # Message when initiating
   d <- NULL

--- a/R/run.R
+++ b/R/run.R
@@ -90,6 +90,7 @@ run <- function(
 
   # Overwrite options locally if supplied directly
   withr::local_options(.new = list(whirl.with_options = with_options))
+  withr::local_options(.new = list(whirl.stop_on = stop_on))
 
   # Message when initiating
   d <- NULL

--- a/R/util_queue_summary.R
+++ b/R/util_queue_summary.R
@@ -15,12 +15,20 @@ util_queue_summary <- function(queue_table) {
       Status = .data$status,
       Hyperlink = vapply(
         X = .data$result,
-        FUN = \(x) utils::head(x[["logs"]], 1),
+        FUN = function(x) {
+          if (is.null(x)) {
+            return("")
+          }
+          utils::head(x[["logs"]], 1)
+        },
         FUN.VALUE = character(1)
       ),
       Information = vapply(
         X = .data$result,
-        FUN = \(x) {
+        FUN = function(x) {
+          if (is.null(x)) {
+            return("")
+          }
           x[["status"]][c("errors", "warnings")] |>
             unlist() |>
             paste0(collapse = "<br>")
@@ -28,5 +36,12 @@ util_queue_summary <- function(queue_table) {
         FUN.VALUE = character(1)
       )
     ) |>
-    dplyr::select("Tag", "Directory", "Filename", "Status", "Hyperlink", "Information")
+    dplyr::select(
+      "Tag",
+      "Directory",
+      "Filename",
+      "Status",
+      "Hyperlink",
+      "Information"
+    )
 }

--- a/R/whirl-options.R
+++ b/R/whirl-options.R
@@ -130,7 +130,7 @@ zephyr::create_option(
 )
 
 zephyr::create_option(
-  name = "stop_on",
+  name = "skip_after",
   default = "never",
   description = "When to stop running more scripts.
   If `error` or `warning` no more steps will be executed after the first error or warning respectively.

--- a/R/whirl-options.R
+++ b/R/whirl-options.R
@@ -128,3 +128,11 @@ zephyr::create_option(
   default = list(),
   description = "List of options to set in the child sessions executing the scripts."
 )
+
+zephyr::create_option(
+  name = "stop_on",
+  default = "never",
+  description = "When to stop running more scripts.
+  If `error` or `warning` no more steps will be executed after the first error or warning respectively.
+  Default `never` continues executing all scripts."
+)

--- a/R/whirl-options.R
+++ b/R/whirl-options.R
@@ -133,6 +133,7 @@ zephyr::create_option(
   name = "skip_after",
   default = "never",
   description = "When to stop running more scripts.
-  If `error` or `warning` no more steps will be executed after the first error or warning respectively.
+  The levels are hierarchical: `warning` stops on both warnings and errors,
+  while `error` stops only on errors (warnings will not trigger skipping).
   Default `never` continues executing all scripts."
 )

--- a/R/whirl_r_session.R
+++ b/R/whirl_r_session.R
@@ -419,6 +419,9 @@ wrs_report_status <- function(status, script, logs) {
     error = zephyr::msg_danger(
       "{script_msg}: Completed with errors. See {cli::qty(logs_msg)}log{?s} {logs_msg}."
     ),
+    skipped = zephyr::msg_info(
+      "{script_msg}: Skipped due to previous {paste(zephyr::get_option('skip_after', 'whirl'), collapse = ' or ')}."
+    ),
     cli::cli_abort(
       "{script}: Completed with unknown status {.emph {status}}. See {cli::qty(logs_msg)}log{?s} {logs_msg}."
     )

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -14,7 +14,7 @@ run(
   out_formats = zephyr::get_option("out_formats", "whirl"),
   log_dir = zephyr::get_option("log_dir", "whirl"),
   with_options = zephyr::get_option("with_options", "whirl"),
-  stop_on = zephyr::get_option("stop_on", "whirl")
+  skip_after = zephyr::get_option("skip_after", "whirl")
 )
 }
 \arguments{
@@ -51,7 +51,7 @@ For more information see the examples of \code{run()} or \code{vignette('whirl')
 
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
 
-\item{stop_on}{When to stop running more scripts.
+\item{skip_after}{When to stop running more scripts.
 If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
 Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -52,7 +52,8 @@ For more information see the examples of \code{run()} or \code{vignette('whirl')
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
 
 \item{skip_after}{When to stop running more scripts.
-If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+The levels are hierarchical: \code{warning} stops on both warnings and errors,
+while \code{error} stops only on errors (warnings will not trigger skipping).
 Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }
 \value{

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -13,7 +13,8 @@ run(
   track_files = zephyr::get_option("track_files", "whirl"),
   out_formats = zephyr::get_option("out_formats", "whirl"),
   log_dir = zephyr::get_option("log_dir", "whirl"),
-  with_options = zephyr::get_option("with_options", "whirl")
+  with_options = zephyr::get_option("with_options", "whirl"),
+  stop_on = zephyr::get_option("stop_on", "whirl")
 )
 }
 \arguments{
@@ -49,6 +50,10 @@ function that takes the script path as input and returns the log directory.
 For more information see the examples of \code{run()} or \code{vignette('whirl')}.. Default: \code{function (x)  dirname(x)}.}
 
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
+
+\item{stop_on}{When to stop running more scripts.
+If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }
 \value{
 A tibble containing the execution results for all the scripts.

--- a/man/whirl-options-params.Rd
+++ b/man/whirl-options-params.Rd
@@ -47,7 +47,8 @@ Any variables matching will not be included in the logs.. Default: \code{c("BASH
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
 
 \item{skip_after}{When to stop running more scripts.
-If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+The levels are hierarchical: \code{warning} stops on both warnings and errors,
+while \code{error} stops only on errors (warnings will not trigger skipping).
 Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }
 \description{

--- a/man/whirl-options-params.Rd
+++ b/man/whirl-options-params.Rd
@@ -45,6 +45,10 @@ start, in milliseconds.. Default: \code{9000}.}
 Any variables matching will not be included in the logs.. Default: \code{c("BASH_FUNC", "_SSL_CERT", "_KEY", "_PAT", "_TOKEN")}.}
 
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
+
+\item{stop_on}{When to stop running more scripts.
+If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }
 \description{
 Internal parameters for reuse in functions

--- a/man/whirl-options-params.Rd
+++ b/man/whirl-options-params.Rd
@@ -46,7 +46,7 @@ Any variables matching will not be included in the logs.. Default: \code{c("BASH
 
 \item{with_options}{List of options to set in the child sessions executing the scripts.. Default: \code{list()}.}
 
-\item{stop_on}{When to stop running more scripts.
+\item{skip_after}{When to stop running more scripts.
 If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
 Default \code{never} continues executing all scripts.. Default: \code{"never"}.}
 }

--- a/man/whirl-options.Rd
+++ b/man/whirl-options.Rd
@@ -161,7 +161,8 @@ List of options to set in the child sessions executing the scripts.
 \subsection{skip_after}{
 
 When to stop running more scripts.
-If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+The levels are hierarchical: \code{warning} stops on both warnings and errors,
+while \code{error} stops only on errors (warnings will not trigger skipping).
 Default \code{never} continues executing all scripts.
 \itemize{
 \item Default: \code{"never"}

--- a/man/whirl-options.Rd
+++ b/man/whirl-options.Rd
@@ -157,4 +157,16 @@ List of options to set in the child sessions executing the scripts.
 \item Environment: \code{R_WHIRL_WITH_OPTIONS}
 }
 }
+
+\subsection{stop_on}{
+
+When to stop running more scripts.
+If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
+Default \code{never} continues executing all scripts.
+\itemize{
+\item Default: \code{"never"}
+\item Option: \code{whirl.stop_on}
+\item Environment: \code{R_WHIRL_STOP_ON}
+}
+}
 }

--- a/man/whirl-options.Rd
+++ b/man/whirl-options.Rd
@@ -158,15 +158,15 @@ List of options to set in the child sessions executing the scripts.
 }
 }
 
-\subsection{stop_on}{
+\subsection{skip_after}{
 
 When to stop running more scripts.
 If \code{error} or \code{warning} no more steps will be executed after the first error or warning respectively.
 Default \code{never} continues executing all scripts.
 \itemize{
 \item Default: \code{"never"}
-\item Option: \code{whirl.stop_on}
-\item Environment: \code{R_WHIRL_STOP_ON}
+\item Option: \code{whirl.skip_after}
+\item Environment: \code{R_WHIRL_SKIP_AFTER}
 }
 }
 }

--- a/man/whirl-package.Rd
+++ b/man/whirl-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Aksel Thomsen \email{oath@novonordisk.com}
   \item Lovemore Gakava \email{lvgk@novonordisk.com}
   \item Cervan Girard \email{cgid@novonordisk.com}
   \item Kristian Troejelsgaard \email{ktqn@novonordisk.com}

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -174,7 +174,7 @@ test_that("Use with_options", {
     expect_equal("world")
 })
 
-test_that("skip_after works", {
+test_that("skip_after warning works", {
   skip_on_cran()
   skip_if_no_quarto()
 
@@ -187,6 +187,39 @@ test_that("skip_after works", {
 
   res$result[[3]] |>
     expect_null()
+
+  res$result[[4]] |>
+    expect_null()
+})
+
+test_that("skip_after warning also skips after error", {
+  skip_on_cran()
+  skip_if_no_quarto()
+
+  res <- test_script(c("success.R", "error.R", "warning.R", "success.R")) |>
+    as.list() |>
+    run(skip_after = "warning")
+
+  res$status |>
+    expect_equal(c("success", "error", "skipped", "skipped"))
+
+  res$result[[3]] |>
+    expect_null()
+
+  res$result[[4]] |>
+    expect_null()
+})
+
+test_that("skip_after error works", {
+  skip_on_cran()
+  skip_if_no_quarto()
+
+  res <- test_script(c("success.R", "warning.R", "error.R", "success.R")) |>
+    as.list() |>
+    run(skip_after = "error")
+
+  res$status |>
+    expect_equal(c("success", "warning", "error", "skipped"))
 
   res$result[[4]] |>
     expect_null()

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -173,3 +173,18 @@ test_that("Use with_options", {
     unlist() |>
     expect_equal("world")
 })
+
+test_that("skip_after works", {
+  skip_on_cran()
+  skip_if_no_quarto()
+
+  res <- test_script(c("success.R", "warning.R", "error.R")) |>
+    as.list() |>
+    run(skip_after = "warning")
+
+  res$status |>
+    expect_equal(c("success", "warning", "skipped"))
+
+  res$result[[3]] |>
+    expect_null()
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -178,13 +178,16 @@ test_that("skip_after works", {
   skip_on_cran()
   skip_if_no_quarto()
 
-  res <- test_script(c("success.R", "warning.R", "error.R")) |>
+  res <- test_script(c("success.R", "warning.R", "error.R", "success.R")) |>
     as.list() |>
     run(skip_after = "warning")
 
   res$status |>
-    expect_equal(c("success", "warning", "skipped"))
+    expect_equal(c("success", "warning", "skipped", "skipped"))
 
   res$result[[3]] |>
+    expect_null()
+
+  res$result[[4]] |>
     expect_null()
 })


### PR DESCRIPTION
## Summary
Add a `skip_after` option that skips remaining steps after an error or warning occurs during batch execution.

Closes #202

## Changes Made
- Add `skip_after` whirl option with values `"never"` (default), `"error"`, or `"warning"`
- Add `skip_after` parameter to `run()`
- Implement skip logic in `internal_run()` — remaining steps are skipped when the condition is met
- Report skipped scripts via `wrs_report_status()` consistent with existing status reporting
- Handle null results for skipped scripts in queue summary and render summary

## Testing
- Unit test for `skip_after` verifying scripts are skipped and results are null
- Existing tests pass

## Checklist
- [x] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge