### PR TITLE
fix: resolve MegaLinter djlint and lychee failures

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,3 @@
+{
+  "exclude": "tests/testthat|megalinter-reports"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @akselthomsen

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.2.9000
+Version: 0.3.2.9001
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,6 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 SystemRequirements: Quarto command line tool
     (<https://github.com/quarto-dev/quarto-cli>).
+Config/roxygen2/version: 8.0.0

--- a/R/biocompute.R
+++ b/R/biocompute.R
@@ -14,35 +14,35 @@
 #'   * *type*: Your project type
 #'   * *etag*: Your `etag` id from the BioCompute Object Portal
 #'
-#' * [Provenance Domain](https://wiki.biocomputeobject.org/Provenance-domain)
+#' * [Provenance Domain](https://wiki.biocomputeobject.org/Provenance_Domain)
 #'   * This is used to track the history of the BCO. Review and signatures go here.
 #'
-#' * [Usability Domain](https://wiki.biocomputeobject.org/Usability-domain)
+#' * [Usability Domain](https://wiki.biocomputeobject.org/Usability_Domain)
 #'   * This is used to improve searchability by allowing a free-text description of the BCO.
 #'   * Provide external document.
 #'
-#' * [Extension Domain](https://wiki.biocomputeobject.org/Extension-domain)
+#' * [Extension Domain](https://wiki.biocomputeobject.org/Extension_Domain)
 #'   * This is used to add any additional structured information that is not directly covered by the BCO.
 #'
-#' * [Description Domain](https://wiki.biocomputeobject.org/Description-domain)
+#' * [Description Domain](https://wiki.biocomputeobject.org/Description_Domain)
 #'   * Contains a structured field for the description of external references, the pipeline steps,
 #' and the relationship of I/O objects.
 #'   * Provide external document.
 #'   * **Note**: Use of `keywords` and `External_Reference` entries are not yet implemented.
 #' To use fill out the entries manually after creating the BioCompute object.`
 #'
-#' * [Execution Domain](https://wiki.biocomputeobject.org/Execution-domain)
+#' * [Execution Domain](https://wiki.biocomputeobject.org/Execution_Domain)
 #'   * Contains fields for the execution of the BCO.
 #'   * **Note**: Use of `external_data_endpoints` not implemented. Fill out manually afterwards if needed.
 #'
-#'* [Parametric Domain](https://wiki.biocomputeobject.org/Parametric-domain)
+#'* [Parametric Domain](https://wiki.biocomputeobject.org/Parametric_Domain)
 #'   * Represents the list of parameters customizing the computational flow which can affect
 #' the output of the calculations.
 #'
 #' * [IO Domain](https://wiki.biocomputeobject.org/Input_and_Output_Domain)
 #'   * Represents the list of global input and output files created by the computational workflow.
 #'
-#' * [Error Domain](https://wiki.biocomputeobject.org/Error-domain)
+#' * [Error Domain](https://wiki.biocomputeobject.org/Error_Domain)
 #'   * Defines the empirical and algorithmic limits and error sources of the BCO.
 #'   * **Note**: Use of this domain is not clearly defined.
 #' It is therefore always left empty in the current implementation.

--- a/R/biocompute.R
+++ b/R/biocompute.R
@@ -14,35 +14,35 @@
 #'   * *type*: Your project type
 #'   * *etag*: Your `etag` id from the BioCompute Object Portal
 #'
-#' * [Provenance Domain](https://wiki.biocomputeobject.org/index.php?title=Provenance-domain)
+#' * [Provenance Domain](https://wiki.biocomputeobject.org/Provenance-domain)
 #'   * This is used to track the history of the BCO. Review and signatures go here.
 #'
-#' * [Usability Domain](https://wiki.biocomputeobject.org/index.php?title=Usability-domain)
+#' * [Usability Domain](https://wiki.biocomputeobject.org/Usability-domain)
 #'   * This is used to improve searchability by allowing a free-text description of the BCO.
 #'   * Provide external document.
 #'
-#' * [Extension Domain](https://wiki.biocomputeobject.org/index.php?title=Extension-domain)
+#' * [Extension Domain](https://wiki.biocomputeobject.org/Extension-domain)
 #'   * This is used to add any additional structured information that is not directly covered by the BCO.
 #'
-#' * [Description Domain](https://wiki.biocomputeobject.org/index.php?title=Description-domain)
+#' * [Description Domain](https://wiki.biocomputeobject.org/Description-domain)
 #'   * Contains a structured field for the description of external references, the pipeline steps,
 #' and the relationship of I/O objects.
 #'   * Provide external document.
 #'   * **Note**: Use of `keywords` and `External_Reference` entries are not yet implemented.
 #' To use fill out the entries manually after creating the BioCompute object.`
 #'
-#' * [Execution Domain](https://wiki.biocomputeobject.org/index.php?title=Execution-domain)
+#' * [Execution Domain](https://wiki.biocomputeobject.org/Execution-domain)
 #'   * Contains fields for the execution of the BCO.
 #'   * **Note**: Use of `external_data_endpoints` not implemented. Fill out manually afterwards if needed.
 #'
-#'* [Parametric Domain](https://wiki.biocomputeobject.org/index.php?title=Parametric-domain)
+#'* [Parametric Domain](https://wiki.biocomputeobject.org/Parametric-domain)
 #'   * Represents the list of parameters customizing the computational flow which can affect
 #' the output of the calculations.
 #'
-#' * [IO Domain](https://wiki.biocomputeobject.org/index.php?title=Iodomain)
+#' * [IO Domain](https://wiki.biocomputeobject.org/Input_and_Output_Domain)
 #'   * Represents the list of global input and output files created by the computational workflow.
 #'
-#' * [Error Domain](https://wiki.biocomputeobject.org/index.php?title=Error-domain)
+#' * [Error Domain](https://wiki.biocomputeobject.org/Error-domain)
 #'   * Defines the empirical and algorithmic limits and error sources of the BCO.
 #'   * **Note**: Use of this domain is not clearly defined.
 #' It is therefore always left empty in the current implementation.

--- a/man/write_biocompute.Rd
+++ b/man/write_biocompute.Rd
@@ -31,20 +31,20 @@ The object consists of the following domains:
 \item \emph{type}: Your project type
 \item \emph{etag}: Your \code{etag} id from the BioCompute Object Portal
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Provenance-domain}{Provenance Domain}
+\item \href{https://wiki.biocomputeobject.org/Provenance-domain}{Provenance Domain}
 \itemize{
 \item This is used to track the history of the BCO. Review and signatures go here.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Usability-domain}{Usability Domain}
+\item \href{https://wiki.biocomputeobject.org/Usability-domain}{Usability Domain}
 \itemize{
 \item This is used to improve searchability by allowing a free-text description of the BCO.
 \item Provide external document.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Extension-domain}{Extension Domain}
+\item \href{https://wiki.biocomputeobject.org/Extension-domain}{Extension Domain}
 \itemize{
 \item This is used to add any additional structured information that is not directly covered by the BCO.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Description-domain}{Description Domain}
+\item \href{https://wiki.biocomputeobject.org/Description-domain}{Description Domain}
 \itemize{
 \item Contains a structured field for the description of external references, the pipeline steps,
 and the relationship of I/O objects.
@@ -52,21 +52,21 @@ and the relationship of I/O objects.
 \item \strong{Note}: Use of \code{keywords} and \code{External_Reference} entries are not yet implemented.
 To use fill out the entries manually after creating the BioCompute object.`
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Execution-domain}{Execution Domain}
+\item \href{https://wiki.biocomputeobject.org/Execution-domain}{Execution Domain}
 \itemize{
 \item Contains fields for the execution of the BCO.
 \item \strong{Note}: Use of \code{external_data_endpoints} not implemented. Fill out manually afterwards if needed.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Parametric-domain}{Parametric Domain}
+\item \href{https://wiki.biocomputeobject.org/Parametric-domain}{Parametric Domain}
 \itemize{
 \item Represents the list of parameters customizing the computational flow which can affect
 the output of the calculations.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Iodomain}{IO Domain}
+\item \href{https://wiki.biocomputeobject.org/Input_and_Output_Domain}{IO Domain}
 \itemize{
 \item Represents the list of global input and output files created by the computational workflow.
 }
-\item \href{https://wiki.biocomputeobject.org/index.php?title=Error-domain}{Error Domain}
+\item \href{https://wiki.biocomputeobject.org/Error-domain}{Error Domain}
 \itemize{
 \item Defines the empirical and algorithmic limits and error sources of the BCO.
 \item \strong{Note}: Use of this domain is not clearly defined.

--- a/man/write_biocompute.Rd
+++ b/man/write_biocompute.Rd
@@ -31,20 +31,20 @@ The object consists of the following domains:
 \item \emph{type}: Your project type
 \item \emph{etag}: Your \code{etag} id from the BioCompute Object Portal
 }
-\item \href{https://wiki.biocomputeobject.org/Provenance-domain}{Provenance Domain}
+\item \href{https://wiki.biocomputeobject.org/Provenance_Domain}{Provenance Domain}
 \itemize{
 \item This is used to track the history of the BCO. Review and signatures go here.
 }
-\item \href{https://wiki.biocomputeobject.org/Usability-domain}{Usability Domain}
+\item \href{https://wiki.biocomputeobject.org/Usability_Domain}{Usability Domain}
 \itemize{
 \item This is used to improve searchability by allowing a free-text description of the BCO.
 \item Provide external document.
 }
-\item \href{https://wiki.biocomputeobject.org/Extension-domain}{Extension Domain}
+\item \href{https://wiki.biocomputeobject.org/Extension_Domain}{Extension Domain}
 \itemize{
 \item This is used to add any additional structured information that is not directly covered by the BCO.
 }
-\item \href{https://wiki.biocomputeobject.org/Description-domain}{Description Domain}
+\item \href{https://wiki.biocomputeobject.org/Description_Domain}{Description Domain}
 \itemize{
 \item Contains a structured field for the description of external references, the pipeline steps,
 and the relationship of I/O objects.
@@ -52,12 +52,12 @@ and the relationship of I/O objects.
 \item \strong{Note}: Use of \code{keywords} and \code{External_Reference} entries are not yet implemented.
 To use fill out the entries manually after creating the BioCompute object.`
 }
-\item \href{https://wiki.biocomputeobject.org/Execution-domain}{Execution Domain}
+\item \href{https://wiki.biocomputeobject.org/Execution_Domain}{Execution Domain}
 \itemize{
 \item Contains fields for the execution of the BCO.
 \item \strong{Note}: Use of \code{external_data_endpoints} not implemented. Fill out manually afterwards if needed.
 }
-\item \href{https://wiki.biocomputeobject.org/Parametric-domain}{Parametric Domain}
+\item \href{https://wiki.biocomputeobject.org/Parametric_Domain}{Parametric Domain}
 \itemize{
 \item Represents the list of parameters customizing the computational flow which can affect
 the output of the calculations.
@@ -66,7 +66,7 @@ the output of the calculations.
 \itemize{
 \item Represents the list of global input and output files created by the computational workflow.
 }
-\item \href{https://wiki.biocomputeobject.org/Error-domain}{Error Domain}
+\item \href{https://wiki.biocomputeobject.org/Error_Domain}{Error Domain}
 \itemize{
 \item Defines the empirical and algorithmic limits and error sources of the BCO.
 \item \strong{Note}: Use of this domain is not clearly defined.


### PR DESCRIPTION
## Summary
Fix MegaLinter failures caused by broken biocompute wiki links and djlint linting generated HTML test fixtures.

## Changes Made
- Update all biocompute wiki domain links in `R/biocompute.R` to use clean URLs (remove `index.php?title=` prefix)
- Fix broken IO Domain link (`Iodomain` → `Input_and_Output_Domain`)
- Add `.djlintrc` config to exclude `tests/testthat` and `megalinter-reports` from djlint

## Testing
- All links verified with `lychee` (14/14 OK)
- `djlint .` passes with 0 errors

## Checklist
- [ ] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge