### PR TITLE
chore: pin workflow calls and action dependencies

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,10 +11,10 @@ runs:
         sudo setcap cap_sys_ptrace=eip /usr/bin/strace
 
     - name: Install Quarto
-      uses: quarto-dev/quarto-actions/setup@v2
+      uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
     - name: Install python packages based on pyproject.toml
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -32,4 +32,3 @@ runs:
       shell: pwsh
       run: |
         echo "VIRTUAL_ENV=$PWD/.venv" | Out-File -FilePath $env:GITHUB_ENV -Append
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -7,28 +7,38 @@ on:
     branches:
       - main
       - master
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 name: All actions
 jobs:
   check-current-version:
     name: Check current version
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@main
+    permissions:
+      contents: read
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
     with:
       use_local_setup_action: true
   pkgdown:
     name: Pkgdown site
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
     with:
       use_local_setup_action: true
   coverage:
     name: Coverage report
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       use_local_setup_action: true
       use_codecov: true
   megalinter:
     name: Megalinter
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whirl
 Title: Log Execution of Scripts
-Version: 0.3.2.9002
+Version: 0.3.2.9003
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Lovemore", "Gakava", , "lvgk@novonordisk.com", role = "aut"),


### PR DESCRIPTION
## Summary
Pin reusable workflow calls and third-party actions to full commit SHAs (with version tag comments) for supply-chain hardening. Apply least-privilege permissions per job and replace `secrets: inherit` with an explicit token passthrough. Add Dependabot to keep the pinned versions current.

## Changes Made
- `.github/workflows/check_and_co.yaml`
  - Pin `r.workflows` reusable workflow calls to SHA `fa1f70c` (v0.1.0)
  - Set top-level `permissions: {}` and add per-job least-privilege `permissions`
  - Replace `secrets: inherit` for coverage with explicit `CODECOV_TOKEN`
- `.github/actions/setup/action.yaml`
  - Pin `quarto-dev/quarto-actions/setup` to `8a96df1` (v2.2.0)
  - Pin `astral-sh/setup-uv` to `37802ad` (v7.6.0)
- `.github/dependabot.yml`: add weekly `github-actions` update schedule

## Testing
- CI workflow runs against this PR

## Checklist
- [ ] PR linked to issue descripting the bug or feature request being addressed
- [x] Code changes have been tested
- [ ] Documentation has been updated, if applicable
- [ ] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge
